### PR TITLE
Improve ProgramGuide state remembering

### DIFF
--- a/demo/src/commonMain/kotlin/eu/wewox/programguide/demo/screens/ProgramGuideStateScreen.kt
+++ b/demo/src/commonMain/kotlin/eu/wewox/programguide/demo/screens/ProgramGuideStateScreen.kt
@@ -37,7 +37,7 @@ import eu.wewox.programguide.demo.ui.components.ProgramCell
 import eu.wewox.programguide.demo.ui.components.TimelineItemCell
 import eu.wewox.programguide.demo.ui.components.TopBar
 import eu.wewox.programguide.demo.ui.theme.SpacingSmall
-import eu.wewox.programguide.rememberProgramGuideState
+import eu.wewox.programguide.rememberSaveableProgramGuideState
 import kotlinx.coroutines.launch
 
 /**
@@ -59,7 +59,7 @@ fun ProgramGuideStateScreen(onBackClick: () -> Unit) {
         var programs by remember { mutableStateOf(createPrograms(channels, timeline)) }
 
         val scope = rememberCoroutineScope()
-        val state = rememberProgramGuideState(
+        val state = rememberSaveableProgramGuideState(
             initialOffset = {
                 val x = getCurrentTimePosition()
                 Offset(x, 0f)

--- a/programguide/src/commonMain/kotlin/eu/wewox/programguide/ProgramGuide.kt
+++ b/programguide/src/commonMain/kotlin/eu/wewox/programguide/ProgramGuide.kt
@@ -24,7 +24,7 @@ import eu.wewox.minabox.MinaBoxScope
 @Composable
 public fun ProgramGuide(
     modifier: Modifier = Modifier,
-    state: ProgramGuideState = rememberProgramGuideState(),
+    state: ProgramGuideState = rememberSaveableProgramGuideState(),
     dimensions: ProgramGuideDimensions = ProgramGuideDefaults.dimensions,
     contentPadding: PaddingValues = PaddingValues(0.dp),
     content: ProgramGuideScope.() -> Unit


### PR DESCRIPTION
- Replace `rememberProgramGuideState` with `rememberSaveableProgramGuideState` to ensure state persistence across configuration changes and deprecate `rememberProgramGuideState`.
- Update `ProgramGuide` composable to use `rememberSaveableProgramGuideState` by default.
- Add a `Saver` implementation to the `ProgramGuideState` for proper state restoration.